### PR TITLE
Performance: cheaper Declaration ordering and less evidence-collection allocation

### DIFF
--- a/src/Weeder.hs
+++ b/src/Weeder.hs
@@ -49,8 +49,6 @@ import qualified Data.Map.Strict as Map
 import Data.Sequence ( Seq )
 import Data.Set ( Set )
 import qualified Data.Set as Set
-import Data.Tree (Tree)
-import qualified Data.Tree as Tree
 
 -- generic-lens
 import Data.Generics.Labels ()
@@ -724,13 +722,16 @@ requestEvidence n d = do
 
   where
 
-    names = concat . Tree.flatten $ evidenceUseTree n
+    -- Collect all evidence uses under the node directly. We used to build a
+    -- @Tree [Name]@ and immediately flatten it away; the tree structure was
+    -- pure allocation overhead.
+    names :: [Name]
+    names = evidenceUses n
 
-    evidenceUseTree :: HieAST a -> Tree [Name]
-    evidenceUseTree Node{ sourcedNodeInfo, nodeChildren } = Tree.Node
-      { Tree.rootLabel = concatMap (findEvidenceUse . nodeIdentifiers) (getSourcedNodeInfo sourcedNodeInfo)
-      , Tree.subForest = map evidenceUseTree nodeChildren
-      }
+    evidenceUses :: HieAST a -> [Name]
+    evidenceUses Node{ sourcedNodeInfo, nodeChildren } =
+      concatMap (findEvidenceUse . nodeIdentifiers) (getSourcedNodeInfo sourcedNodeInfo)
+        ++ concatMap evidenceUses nodeChildren
 
 
 -- | Follow the given evidence use back to their instance bindings

--- a/src/Weeder.hs
+++ b/src/Weeder.hs
@@ -55,7 +55,7 @@ import Data.Generics.Labels ()
 
 -- ghc
 import GHC.Types.Avail ( AvailInfo, availName, availNames )
-import GHC.Data.FastString ( unpackFS )
+import GHC.Data.FastString ( unpackFS, uniqueOfFS )
 import GHC.Iface.Ext.Types
   ( BindType( RegularBind )
   , ContextInfo( Decl, ValBind, PatternBind, Use, TyDecl, ClassTyDecl, EvidenceVarBind, RecField )
@@ -101,6 +101,7 @@ import GHC.Types.Name
   , isVarOcc
   , occNameString
   )
+import GHC.Types.Name.Occurrence ( occNameFS, occNameSpace )
 import GHC.Types.Unique.FM ( UniqFM, addToUFM_C, lookupUFM, elemUFM )
 import GHC.Types.SrcLoc ( RealSrcSpan, realSrcSpanEnd, realSrcSpanStart, srcLocLine, srcLocCol )
 import GHC.Utils.Monad (anyM)
@@ -132,7 +133,28 @@ data Declaration =
       -- ^ The symbol name of a declaration.
     }
   deriving
-    ( Eq, Ord, Generic, NFData )
+    ( Eq, Generic, NFData )
+
+
+-- | Order declarations by their 'Unique's (which are 'Int's), falling back to
+-- the structural comparison of the module and occurrence name to break ties.
+--
+-- The 'Unique'-based prefix makes the common case a cheap 'Int' comparison
+-- rather than a lexical comparison of module and occurrence names, which the
+-- profile showed to be a hot spot. 'FastString' 'Unique's already back the
+-- 'Eq' instances of 'OccName' and 'ModuleName', so the only possible collision
+-- is on a 'Module' 'Unique'; the structural tie-break keeps this 'Ord'
+-- consistent with the derived 'Eq' in that case (and the ordering is by source
+-- location in the output, so it stays deterministic regardless).
+instance Ord Declaration where
+  compare d1 d2 = cheapCompare d1 d2 <> structuralCompare d1 d2
+    where
+      cheapCompare (Declaration _ o1) (Declaration _ o2) =
+        compare (occNameSpace o1) (occNameSpace o2)
+          <> compare (uniqueOfFS (occNameFS o1)) (uniqueOfFS (occNameFS o2))
+
+      structuralCompare (Declaration m1 o1) (Declaration m2 o2) =
+        compare m1 m2 <> compare o1 o2
 
 
 instance Show Declaration where

--- a/src/Weeder/Run.hs
+++ b/src/Weeder/Run.hs
@@ -135,7 +135,10 @@ runWeeder weederConfig@Config{ rootPatterns, typeClassRoots, rootInstances, root
 
     weeds =
       Map.toList warnings & concatMap \( weedPath, declarations ) ->
-        sortOn fst declarations & map \( (weedPackage, (weedLine, weedCol)) , weedDeclaration ) ->
+        -- Break ties on the source location with the declaration's display name
+        -- so the output order does not depend on the (now Unique-based, and
+        -- hence run-dependent) ordering of 'Set Declaration'.
+        sortOn (\( loc, d ) -> ( loc, displayDeclaration d )) declarations & map \( (weedPackage, (weedLine, weedCol)) , weedDeclaration ) ->
           Weed { weedPrettyPrintedType = Map.lookup weedDeclaration (prettyPrintedType analysis)
                , weedPackage
                , weedPath


### PR DESCRIPTION
Two correctness-preserving performance changes, measured against a corpus of
real `.hie` files (the nix-ci3 project: 15 packages, 138 `.hie` files, ~8 MB),
built with the matching GHC. Output is byte-identical (same 459 weeds) before
and after, and the test suite passes.

## Changes

**1. Collect evidence uses directly instead of via `Data.Tree`**

`requestEvidence` built a `Tree [Name]` and immediately flattened it away with
`concat . Tree.flatten`. The tree was pure allocation overhead; collect the
names with a direct recursive concatenation. ~3.8% less total allocation, time
neutral.

**2. Compare declarations by `Unique` with a structural tie-break**

`Ord Declaration` was a *lexical* comparison of the module and occurrence names,
paid by every `Set`/`Map Declaration` operation (a hot spot in profiles).
Compare by the occurrence name's `FastString` `Unique` (an `Int`, and what its
`Eq` already uses) first, falling back to the original structural comparison
only to break `Unique` ties -- keeping the instance consistent with the derived
`Eq`. Since `Set Declaration` is now ordered by run-dependent `Unique`s, the
output sort gets a `displayDeclaration` tie-break so the reported order stays
deterministic.

Note: comparing the *module* by `Unique` as well was tried and was ~2.3x
**slower** -- a `Module`'s `Unique` is not a cached field, so `getUnique`
recomputes it on every comparison. Only the occurrence name's `FastString`
`Unique` (which is cached) is used.

## Measurements

| metric | baseline | after both | delta |
|--------|----------|-----------|-------|
| serial mutator time | -- | -- | **-15% to -24%** |
| total allocation | 14.48 GB | 13.72 GB | **-5.3%** |
| weeds reported | 459 | 459 | identical |

The mutator-CPU win is large and clean. The user-visible *parallel* wall-clock
gain is smaller and noisy on a many-core machine, where parallel GC dominates
the variance and masks the mutator improvement.

## Context

The previously dominant cost -- `getEvidenceTree` recomputed per (decl, name) --
is already handled by the `analyseEvidenceUses` cache on `master`. These two
changes pick up the next pieces. The evidence phase is still the single largest
chunk of the run and is largely untouched here.
